### PR TITLE
Add a placeholder for Pancake game framework

### DIFF
--- a/Pancake/README.md
+++ b/Pancake/README.md
@@ -1,0 +1,5 @@
+# js13kBreakout using Pancake
+
+Breakout game using Pancake for the js13kGames competition.
+
+https://github.com/Rabios/Pancake


### PR DESCRIPTION
I've noticed Pancake could be added to the list, as it has everything needed to create a Breakout game. So I purpose adding this placeholder as a reminder.

Maybe @Rabios can implement the game later.