### PR TITLE
lock litecanvas version

### DIFF
--- a/Litecanvas/package-lock.json
+++ b/Litecanvas/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@litecanvas/utils": "^0.*",
-        "litecanvas": "^0.*"
+        "@litecanvas/utils": "0.3.2",
+        "litecanvas": "0.49.0"
       },
       "devDependencies": {
         "esbuild": "^0.20.1"

--- a/Litecanvas/package.json
+++ b/Litecanvas/package.json
@@ -15,7 +15,7 @@
     "esbuild": "^0.20.1"
   },
   "dependencies": {
-    "@litecanvas/utils": "^0.*",
-    "litecanvas": "^0.*"
+    "@litecanvas/utils": "0.3.2",
+    "litecanvas": "0.49.0"
   }
 }


### PR DESCRIPTION
Litecanvas is constantly changing in this "alpha" phase. So I'm temporarily going to leave that version locked until a stable version comes along.